### PR TITLE
Add animation preference store

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,20 @@
-import { createApp } from 'vue';
-import App from './App.vue';
-import router from './router';
-import './assets/tailwind.css';
-import './assets/css/themes.css'; // <-- AÑADE ESTA LÍNEA (ajusta la ruta si lo guardaste en otro lugar)
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+import './assets/tailwind.css'
+import './assets/css/themes.css'
+import { createPinia } from 'pinia'
+import { useAppStore } from './stores'
 
 // 1. Importa el plugin y su CSS
-import Toast from 'vue-toastification';
-import 'vue-toastification/dist/index.css';
+import Toast from 'vue-toastification'
+import 'vue-toastification/dist/index.css'
 
-const app = createApp(App);
+const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
+const store = useAppStore()
+store.loadAnimationsPref()
 
 // 2. Opcional: Define las opciones de configuración para las notificaciones
 const options = {
@@ -24,11 +30,11 @@ const options = {
     closeButton: "button",
     icon: true,
     rtl: false
-};
+}
 
 // 3. Registra el router y LUEGO el plugin Toast ANTES de montar la app
-app.use(router);
-app.use(Toast, options);
+app.use(router)
+app.use(Toast, options)
 
 // 4. Monta la aplicación
-app.mount('#app');
+app.mount('#app')

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+
+const STORAGE_KEY = 'animations-enabled'
+
+export const useAppStore = defineStore('app', {
+  state: () => ({
+    animationsEnabled: true
+  }),
+  actions: {
+    loadAnimationsPref() {
+      try {
+        const saved = localStorage.getItem(STORAGE_KEY)
+        if (saved !== null) {
+          this.animationsEnabled = saved === 'true'
+        }
+      } catch (e) {
+        console.error('Failed to load animations preference', e)
+      }
+    },
+    saveAnimationsPref() {
+      try {
+        localStorage.setItem(STORAGE_KEY, this.animationsEnabled)
+      } catch (e) {
+        console.error('Failed to save animations preference', e)
+      }
+    },
+    toggleAnimations() {
+      this.animationsEnabled = !this.animationsEnabled
+      this.saveAnimationsPref()
+    },
+    setAnimationsEnabled(value) {
+      this.animationsEnabled = value
+      this.saveAnimationsPref()
+    }
+  }
+})

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -6,7 +6,8 @@
 
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10 pb-16">
       <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
-        <div v-if="usuario" class="bg-gradient-to-r from-blue-900/90 to-blue-800/90 backdrop-blur-sm text-white py-2 px-4 rounded-lg shadow-lg shadow-blue-500/20 flex items-center gap-2 border border-blue-500/30 animate-[fade-in-right_0.6s_ease-out]">
+        <div v-if="usuario" class="bg-gradient-to-r from-blue-900/90 to-blue-800/90 backdrop-blur-sm text-white py-2 px-4 rounded-lg shadow-lg shadow-blue-500/20 flex items-center gap-2 border border-blue-500/30"
+             :class="store.animationsEnabled ? 'animate-[fade-in-right_0.6s_ease-out]' : ''">
           <div class="bg-blue-500/30 rounded-full p-1 flex items-center justify-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
@@ -18,11 +19,13 @@
           </div>
         </div>
 
-        <h2 class="text-2xl md:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-emerald-300 text-center glow-emerald animate-[fade-in-down_0.6s_ease-out]">
+        <h2 class="text-2xl md:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-emerald-400 to-emerald-300 text-center glow-emerald"
+            :class="store.animationsEnabled ? 'animate-[fade-in-down_0.6s_ease-out]' : ''">
           Dashboard Empresarial
         </h2>
 
-        <div class="bg-gradient-to-r from-emerald-900/80 to-emerald-800/80 backdrop-blur-md text-white py-2 px-4 rounded-lg shadow-lg shadow-emerald-500/20 border border-emerald-500/30 animate-[fade-in-left_0.6s_ease-out]">
+        <div class="bg-gradient-to-r from-emerald-900/80 to-emerald-800/80 backdrop-blur-md text-white py-2 px-4 rounded-lg shadow-lg shadow-emerald-500/20 border border-emerald-500/30"
+             :class="store.animationsEnabled ? 'animate-[fade-in-left_0.6s_ease-out]' : ''">
           <div class="flex flex-col items-end">
             <div class="text-xs opacity-90 font-medium">{{ currentDate }}</div>
             <div class="font-mono font-bold text-base leading-tight tracking-wider text-emerald-300">{{ currentTime }}</div>
@@ -364,9 +367,14 @@
 import Chart from 'chart.js/auto';
 import { db } from '../firebase/firebase'; // Asegúrate que la ruta a tu config de Firebase sea correcta
 import { collection, getDocs, query, where, orderBy, limit, Timestamp } from 'firebase/firestore';
+import { useAppStore } from '../stores'
 
 export default {
   name: 'EnterpriseDashboard',
+  setup() {
+    const store = useAppStore()
+    return { store }
+  },
   data() {
     return {
       usuario: 'Usuario Principal', // Puedes obtenerlo de tu sistema de auth

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -30,6 +30,10 @@
 </template>
 
 <script setup>
+import { useAppStore } from '../stores'
+
+const store = useAppStore()
+
 const backgroundStyle = {
   backgroundImage: "url('/assets/futuristic-bg.avif')",
   backgroundSize: 'cover',
@@ -38,11 +42,13 @@ const backgroundStyle = {
 
 // 2. Funciones para controlar la animación de entrada
 const beforeEnter = (el) => {
+  if (!store.animationsEnabled) return
   el.style.opacity = 0
   el.style.transform = 'translateY(20px)'
 }
 
 const enter = (el) => {
+  if (!store.animationsEnabled) return
   el.style.opacity = 1
   el.style.transform = 'translateY(0)'
   el.style.transition = 'all 0.6s ease-out'


### PR DESCRIPTION
## Summary
- implement Pinia store to track animation preference
- load/store the value in localStorage
- initialise Pinia in `main.js`
- use animation setting in `HomeView` and `Dashboard` components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b03f8d20832c98ea68381b3780ea