### PR TITLE
Add Vitest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 financiera
 # financiera
 # financiera
+
+## Testing
+
+Install dependencies and run the test suite using [Vitest](https://vitest.dev):
+
+```bash
+npm install
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.4.1",
-        "vite": "^6.2.5"
+        "vite": "^6.2.5",
+        "vitest": "^1.5.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "chart.js": "^4.4.9",
@@ -26,6 +27,7 @@
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
-    "vite": "^6.2.5"
+    "vite": "^6.2.5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/sample.test.js
+++ b/src/sample.test.js
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('sample', () => {
+  it('adds numbers correctly', () => {
+    expect(1 + 1).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add `vitest` and a `test` script
- include `vitest` in lockfile
- create a sample test
- document how to run tests in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6847b03235b0832ca827a672629b57e0