### PR TITLE
Add global fade transition

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -118,11 +118,9 @@
     </div>
     
     <main class="pt-4 pb-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <router-view v-slot="{ Component }">
-        <transition name="page-transition" mode="out-in">
-          <component :is="Component" />
-        </transition>
-      </router-view>
+      <transition name="fade" mode="out-in">
+        <router-view />
+      </transition>
     </main>
     
     <footer v-if="isAuthenticated" class="bg-gray-900/80 backdrop-blur-md border-t border-emerald-500/20 py-6 text-gray-400 text-sm animate-fade-in shadow-lg shadow-emerald-500/5">
@@ -298,22 +296,6 @@ onUnmounted(() => {
 </script>
 
 <style>
-/* Transiciones de página mejoradas */
-.page-transition-enter-active,
-.page-transition-leave-active {
-  transition: all 0.3s ease-out;
-}
-
-.page-transition-enter-from {
-  opacity: 0;
-  transform: translateY(20px);
-}
-
-.page-transition-leave-to {
-  opacity: 0;
-  transform: translateY(-20px);
-}
-
 /* Animaciones para elementos */
 .animate-fade-in {
   animation: fadeIn 0.5s ease-out forwards;

--- a/src/assets/css/transitions.css
+++ b/src/assets/css/transitions.css
@@ -1,0 +1,9 @@
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,8 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 import './assets/tailwind.css';
-import './assets/css/themes.css'; // <-- AÑADE ESTA LÍNEA (ajusta la ruta si lo guardaste en otro lugar)
+import './assets/css/themes.css';
+import './assets/css/transitions.css';
 
 // 1. Importa el plugin y su CSS
 import Toast from 'vue-toastification';


### PR DESCRIPTION
## Summary
- wrap `router-view` in a `<transition>` wrapper
- add global fade CSS classes
- load the new stylesheet in the app

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b040ac88832cb04bd279b34a8292