### PR TITLE
Add corporativo theme and selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 financiera
 # financiera
 # financiera
+
+## Theme selection
+
+Use the theme selector in the application's top bar to switch between `light`, `dark` and the new `corporativo` appearance. The chosen option is saved and restored on your next visit.

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,15 @@
             <div class="text-xs text-emerald-500/70">
               {{ formattedDate }}
             </div>
+            <select
+              v-model="selectedTheme"
+              @change="setThemePreference(selectedTheme)"
+              class="ml-3 bg-gray-800/50 border border-emerald-500/20 text-emerald-300 text-sm rounded-md px-2 py-1 focus:outline-none"
+            >
+              <option value="light">Claro</option>
+              <option value="dark">Oscuro</option>
+              <option value="corporativo">Corporativo</option>
+            </select>
           </div>
           
           <button @click="menuOpen = !menuOpen" class="md:hidden text-emerald-400 hover:text-emerald-300 transition-colors duration-300 p-2 rounded-lg hover:bg-gray-800/50">
@@ -153,6 +162,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { getAuth, onAuthStateChanged, signOut } from 'firebase/auth'
+import { useTheme } from './composables/useTheme'
 
 // Estado de la aplicación
 const isAuthenticated = ref(false)
@@ -165,6 +175,11 @@ const router = useRouter()
 const route = useRoute()
 let unsubscribe
 let clockInterval
+const { currentTheme, setThemePreference } = useTheme()
+const selectedTheme = ref(currentTheme.value)
+watch(currentTheme, (v) => {
+  selectedTheme.value = v
+})
 
 // Cierra el menú desplegable cuando cambia la ruta
 watch(() => route.path, () => {

--- a/src/assets/css/themes.css
+++ b/src/assets/css/themes.css
@@ -103,3 +103,54 @@
   --chart-tooltip-text: #F3F4F6;
   --chart-legend-text: #9CA3AF;
 }
+
+/* ------------------------------ */
+/* -- TEMA CORPORATIVO (NUEVO) -- */
+/* ------------------------------ */
+.theme-corporativo {
+  --bg-primary: #f5f7fa;
+  --bg-secondary: #ffffff;
+  --bg-accent: #e8edf3;
+  --bg-navbar: rgba(0, 80, 160, 0.85);
+  --bg-modal: rgba(245, 247, 250, 0.95);
+
+  --text-primary: #00264d;
+  --text-secondary: #335b83;
+  --text-accent: #0a84c1;
+  --text-on-accent-bg: #ffffff;
+
+  --border-primary: #c4d0e0;
+  --border-secondary: #e2eaf2;
+  --border-accent: #0a84c1;
+
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --shadow-color-navbar: rgba(0, 80, 160, 0.2);
+
+  --brand-emerald: #10B981;
+  --brand-emerald-text: #059669;
+  --brand-red: #EF4444;
+  --brand-red-text: #DC2626;
+  --brand-blue: #3B82F6;
+  --brand-blue-text: #2563EB;
+  --brand-purple: #8B5CF6;
+  --brand-purple-text: #7C3AED;
+  --brand-pink: #EC4899;
+  --brand-pink-text: #DB2777;
+  --brand-yellow: #F59E0B;
+  --brand-yellow-text: #D97706;
+
+  --input-bg: #ffffff;
+  --input-border: #c4d0e0;
+  --input-text: #00264d;
+  --input-focus-ring: #0a84c1;
+
+  --scrollbar-thumb: #a0aec0;
+  --scrollbar-track: #e2eaf2;
+
+  --chart-grid-color: rgba(0, 0, 0, 0.1);
+  --chart-tick-color: #335b83;
+  --chart-tooltip-bg: rgba(255, 255, 255, 0.95);
+  --chart-tooltip-text: #00264d;
+  --chart-legend-text: #335b83;
+}
+

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -1,80 +1,68 @@
 // src/composables/useTheme.js
-import { ref, onMounted, watch, readonly } from 'vue';
+import { ref, onMounted, readonly } from 'vue'
 
-const THEME_STORAGE_KEY = 'app-theme';
+const THEME_STORAGE_KEY = 'app-theme'
 
-// Estado reactivo para el tema actual (true si es oscuro, false si es claro)
-// Lo definimos fuera para que sea un singleton si se usa en múltiples sitios,
-// aunque para este caso, con App.vue controlándolo, no es estrictamente necesario.
-const isDark = ref(false);
+// Estado reactivo para el tema actual
+const currentTheme = ref('light')
 
 export function useTheme() {
-  const applyTheme = (themeIsDark) => {
-    if (themeIsDark) {
-      document.documentElement.classList.add('theme-dark');
-    } else {
-      document.documentElement.classList.remove('theme-dark');
+  const applyTheme = (themeName) => {
+    document.documentElement.classList.remove('theme-dark', 'theme-corporativo')
+    if (themeName === 'dark') {
+      document.documentElement.classList.add('theme-dark')
+    } else if (themeName === 'corporativo') {
+      document.documentElement.classList.add('theme-corporativo')
     }
-    isDark.value = themeIsDark;
-  };
+    currentTheme.value = themeName
+  }
 
-  const setThemePreference = (themeIsDark) => {
-    applyTheme(themeIsDark);
+  const setThemePreference = (themeName) => {
+    applyTheme(themeName)
     try {
-      localStorage.setItem(THEME_STORAGE_KEY, themeIsDark ? 'dark' : 'light');
+      localStorage.setItem(THEME_STORAGE_KEY, themeName)
     } catch (e) {
-      console.error('Failed to save theme preference:', e);
+      console.error('Failed to save theme preference:', e)
     }
-  };
+  }
 
   const toggleTheme = () => {
-    setThemePreference(!isDark.value);
-  };
+    setThemePreference(currentTheme.value === 'dark' ? 'light' : 'dark')
+  }
 
   const initializeTheme = () => {
-    let initialThemeIsDark;
-    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    let initialTheme
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY)
 
     if (savedTheme) {
-      initialThemeIsDark = savedTheme === 'dark';
+      initialTheme = savedTheme
+    } else if (
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    ) {
+      initialTheme = 'dark'
     } else {
-      // Si no hay tema guardado, usar la preferencia del sistema
-      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        initialThemeIsDark = true;
-      } else {
-        initialThemeIsDark = false; // Default a claro si no hay preferencia o no se puede detectar
+      initialTheme = 'light'
+    }
+    applyTheme(initialTheme)
+  }
+
+  onMounted(() => {
+    initializeTheme()
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const systemThemeChangeHandler = (e) => {
+      if (!localStorage.getItem(THEME_STORAGE_KEY)) {
+        applyTheme(e.matches ? 'dark' : 'light')
       }
     }
-    applyTheme(initialThemeIsDark); // Aplicar sin guardar en localStorage, ya que se está inicializando desde allí o desde system pref
-  };
+    mediaQuery.addEventListener('change', systemThemeChangeHandler)
+  })
 
-  // Inicializar el tema cuando el composable se usa por primera vez
-  // (o cuando el componente que lo usa se monta)
-  onMounted(() => {
-    initializeTheme();
-
-    // Escuchar cambios en la preferencia del sistema (opcional, pero bueno para la UX)
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const systemThemeChangeHandler = (e) => {
-      // Solo actualiza si no hay una preferencia explícita guardada por el usuario
-      if (!localStorage.getItem(THEME_STORAGE_KEY)) {
-        applyTheme(e.matches);
-      }
-    };
-    mediaQuery.addEventListener('change', systemThemeChangeHandler);
-    
-    // Limpiar el listener cuando el componente se desmonte
-    // Esto es más relevante si el composable se usa en componentes que se montan/desmontan.
-    // En App.vue, vivirá tanto como la app.
-    // onUnmounted(() => {
-    //   mediaQuery.removeEventListener('change', systemThemeChangeHandler);
-    // });
-  });
-
-  // Exponer el estado del tema como readonly y la función para cambiarlo
   return {
-    isDark: readonly(isDark),
+    currentTheme: readonly(currentTheme),
     toggleTheme,
-    setThemePreference // Exponer por si se quiere setear un tema directamente
-  };
+    setThemePreference,
+  }
 }
+


### PR DESCRIPTION
## Summary
- provide a new corporate color palette in `themes.css`
- extend `useTheme` composable for light, dark and corporativo themes
- add a theme selector dropdown in `App.vue`
- document how to change themes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b3bd01c0832c8893c70922c6a601