### PR TITLE
Remove npm test from GitHub workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,3 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test


### PR DESCRIPTION
## Summary
- drop `npm test` from Node.js CI workflow because the project has no tests

## Testing
- `npm run build --if-present`

------
https://chatgpt.com/codex/tasks/task_e_6847c49b5f64832c94aa8a959506055d