### PR TITLE
Use CSS variables for theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 text-slate-800 font-sans">
+  <body class="font-sans" style="background: var(--bg-primary); color: var(--text-primary)">
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 font-sans text-slate-800">
+  <div class="min-h-screen font-sans" style="background: var(--bg-primary); color: var(--text-primary)">
     <div v-if="isAuthenticated" class="sticky top-0 z-50 bg-gray-900/70 backdrop-blur-xl shadow-lg shadow-emerald-500/10 mb-6 animate-fade-in border-b border-emerald-500/20">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center py-4">
@@ -449,7 +449,8 @@ html {
 /* Fuente moderna y responsiva */
 body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  @apply text-slate-800 bg-slate-100;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
 }
 
 /* Media queries para optimizar la experiencia en dispositivos */


### PR DESCRIPTION
## Summary
- switch hard-coded gradient colors in `index.html` to CSS variables
- use theme variables for the background of the root App component
- tie `body` text and background colors to theme variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848720caac8832c9545e4adc6d9bda6