### PR TITLE
Enhance dashboard with quick actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The dashboard view (`src/views/Dashboard.vue`) exposes several ready‑made bloc
 - **Summary cards** – `<div class="summary-card">` for KPIs.
 - **Chart containers** – `<div class="chart-container">` for charts.
 - **Metric cards** – `<div class="metric-card">` for compact statistics.
+- **Quick actions** – `<QuickActions>` with shortcuts to common pages.
 
 When adding new metrics reuse these containers to keep consistent spacing and animations. Place new cards within the existing grids and prefer CSS variables for colors so all themes stay in sync.
 

--- a/src/components/QuickActions.vue
+++ b/src/components/QuickActions.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="quick-actions">
+    <button v-for="action in actions" :key="action.label" class="quick-action" @click="action.onClick">
+      <component :is="action.icon" class="w-5 h-5 mr-1" />
+      {{ action.label }}
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  actions: {
+    type: Array,
+    default: () => []
+  }
+})
+</script>
+
+<style scoped>
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-action {
+  @apply bg-gray-700/60 text-gray-200 px-3 py-1.5 rounded-lg text-sm flex items-center transition-colors border border-gray-600/50;
+}
+.quick-action:hover {
+  @apply bg-emerald-600/30 border-emerald-500 text-emerald-300;
+}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -83,6 +83,7 @@
           </div>
         </div>
       </div>
+  <QuickActions :actions="quickActions" class="mt-4" />
 
   <div v-if="vistaSeleccionada === 'general' && !isLoading">
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-6 mb-10">
@@ -334,13 +335,38 @@ import { useDashboardOptions } from "../composables/useDashboard"
 import { useAppStore } from "../stores"
 import SummaryCard from "../components/SummaryCard.vue"
 import DataTable from "../components/DataTable.vue"
+import QuickActions from "../components/QuickActions.vue"
+import router from "../router"
 
 export default {
   name: "EnterpriseDashboard",
-  components: { SummaryCard, DataTable },
+  components: { SummaryCard, DataTable, QuickActions },
   setup() {
     const store = useAppStore();
-    return { store };
+    const quickActions = [
+      {
+        label: 'Nueva Tienda',
+        icon: {
+          template: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>`
+        },
+        onClick: () => { router.push('/tiendas'); }
+      },
+      {
+        label: 'Registrar Cobro',
+        icon: {
+          template: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-3-3v6m7 2a2 2 0 012 2H5a2 2 0 012-2h12z" /></svg>`
+        },
+        onClick: () => { router.push('/cobros'); }
+      },
+      {
+        label: 'Gestión de Cotizaciones',
+        icon: {
+          template: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>`
+        },
+        onClick: () => { router.push('/cotizaciones'); }
+      }
+    ];
+    return { store, quickActions };
   },
   ...useDashboardOptions()
 }


### PR DESCRIPTION
## Summary
- add a QuickActions component with Tailwind styling
- include QuickActions in the dashboard with router shortcuts
- document quick actions in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848ba2e3218832cbeb13ae7b88916ca