### PR TITLE
Add tiendas theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ financiera
 
 ## Theme selection
 
-Use the theme selector in the application's top bar to switch between `light`, `dark`, `corporativo` and the new `md3` (Material Design 3) appearance. The chosen option is saved and restored on your next visit.
+Use the theme selector in the application's top bar to switch between `light`, `dark`, `corporativo`, `md3` (Material Design 3) and the new `tiendas` appearance. The chosen option is saved and restored on your next visit.
 
 ## Environment variables
 
@@ -45,7 +45,7 @@ module.exports = {
 }
 ```
 
-Colors and themes are defined using CSS variables in `src/assets/css/themes.css`. Three themes are available: **light**, **dark** and **corporativo**. Each theme defines variables such as `--bg-primary`, `--text-primary` and brand accent colors.
+Colors and themes are defined using CSS variables in `src/assets/css/themes.css`. Four themes are available: **light**, **dark**, **corporativo** and **tiendas** (plus the optional **md3**). Each theme defines variables such as `--bg-primary`, `--text-primary` and brand accent colors.
 
 Example corporate palette:
 - `--bg-primary: #f5f7fa`

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,7 @@
               <option value="dark">Oscuro</option>
               <option value="corporativo">Corporativo</option>
               <option value="md3">Material 3</option>
+              <option value="tiendas">Tiendas</option>
             </select>
           </div>
           

--- a/src/assets/css/themes.css
+++ b/src/assets/css/themes.css
@@ -204,3 +204,53 @@
   --chart-legend-text: #49454F;
 }
 
+
+/* ------------------------------ */
+/* --- TEMA TIENDAS (NUEVO) ----- */
+/* ------------------------------ */
+.theme-tiendas {
+  --bg-primary: #f7f6f3;
+  --bg-secondary: #ffffff;
+  --bg-accent: #fff8e6;
+  --bg-navbar: rgba(245, 158, 11, 0.85);
+  --bg-modal: rgba(255, 255, 255, 0.95);
+
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-accent: #d97706;
+  --text-on-accent-bg: #ffffff;
+
+  --border-primary: #d1d5db;
+  --border-secondary: #e5e7eb;
+  --border-accent: #fbbf24;
+
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --shadow-color-navbar: rgba(245, 158, 11, 0.2);
+
+  --brand-emerald: #34d399;
+  --brand-emerald-text: #059669;
+  --brand-red: #ef4444;
+  --brand-red-text: #dc2626;
+  --brand-blue: #3b82f6;
+  --brand-blue-text: #2563eb;
+  --brand-purple: #a855f7;
+  --brand-purple-text: #7e22ce;
+  --brand-pink: #ec4899;
+  --brand-pink-text: #db2777;
+  --brand-yellow: #fbbf24;
+  --brand-yellow-text: #d97706;
+
+  --input-bg: #ffffff;
+  --input-border: #d1d5db;
+  --input-text: #1f2937;
+  --input-focus-ring: #f59e0b;
+
+  --scrollbar-thumb: #fbbf24;
+  --scrollbar-track: #fef3c7;
+
+  --chart-grid-color: rgba(0, 0, 0, 0.1);
+  --chart-tick-color: #4b5563;
+  --chart-tooltip-bg: rgba(255, 255, 255, 0.95);
+  --chart-tooltip-text: #1f2937;
+  --chart-legend-text: #4b5563;
+}

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -4,17 +4,19 @@ import { ref, onMounted, readonly } from 'vue'
 const THEME_STORAGE_KEY = 'app-theme'
 
 // Estado reactivo para el tema actual
-const currentTheme = ref('light')
+const currentTheme = ref('tiendas')
 
 export function useTheme() {
   const applyTheme = (themeName) => {
-    document.documentElement.classList.remove('theme-dark', 'theme-corporativo', 'theme-md3')
+    document.documentElement.classList.remove('theme-dark', 'theme-corporativo', 'theme-md3', 'theme-tiendas')
     if (themeName === 'dark') {
       document.documentElement.classList.add('theme-dark')
     } else if (themeName === 'corporativo') {
       document.documentElement.classList.add('theme-corporativo')
     } else if (themeName === 'md3') {
       document.documentElement.classList.add('theme-md3')
+    } else if (themeName === 'tiendas') {
+      document.documentElement.classList.add('theme-tiendas')
     }
     currentTheme.value = themeName
   }
@@ -44,7 +46,7 @@ export function useTheme() {
     ) {
       initialTheme = 'dark'
     } else {
-      initialTheme = 'light'
+      initialTheme = 'tiendas'
     }
     applyTheme(initialTheme)
   }


### PR DESCRIPTION
## Summary
- add new `tiendas` theme styling
- update theme selector with Tiendas option
- make `tiendas` the default selected theme
- document new theme in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684904043da0832c994d19a7f1095e27