### PR TITLE
Refactor colors to use CSS variables

### DIFF
--- a/src/assets/css/light-components.css
+++ b/src/assets/css/light-components.css
@@ -1,17 +1,33 @@
 /* Shared light theme components */
 .light-card {
-  @apply bg-white shadow rounded-lg p-4 border border-gray-200;
+  @apply shadow rounded-lg p-4 border;
+  background-color: var(--bg-secondary);
+  border-color: var(--border-secondary);
+  color: var(--text-primary);
 }
 
 .md3-card {
-  @apply bg-white rounded-2xl shadow-sm border border-gray-200 p-4 transition-transform duration-200 ease-in-out;
+  @apply rounded-2xl shadow-sm border p-4 transition-transform duration-200 ease-in-out;
+  background-color: var(--bg-secondary);
+  border-color: var(--border-secondary);
+  color: var(--text-primary);
 }
 .md3-card:hover {
   @apply shadow-md -translate-y-1;
 }
 
 .input-primary {
-  @apply w-full px-3 py-2 rounded-lg border border-gray-300 bg-white text-slate-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition-all duration-150 text-sm shadow-sm disabled:bg-slate-50 disabled:text-slate-400 disabled:cursor-not-allowed;
+  @apply w-full px-3 py-2 rounded-lg border focus:outline-none focus:ring-2 transition-all duration-150 text-sm shadow-sm disabled:cursor-not-allowed;
+  background-color: var(--input-bg);
+  border-color: var(--input-border);
+  color: var(--input-text);
+}
+.input-primary::placeholder {
+  color: var(--text-secondary);
+}
+.input-primary:focus {
+  --tw-ring-color: var(--input-focus-ring);
+  border-color: var(--input-focus-ring);
 }
 .select-input {
   @apply appearance-none bg-no-repeat bg-right pr-8;
@@ -23,5 +39,7 @@
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%2314b8a6' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
 }
 .option-light {
-  @apply bg-white text-slate-700;
+  @apply;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
 }

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -1,17 +1,19 @@
 <template>
-  <div class="overflow-hidden rounded-xl border border-gray-700/50 shadow-inner" :class="outerClass">
+  <div class="overflow-hidden rounded-xl border shadow-inner" :class="outerClass"
+       style="background-color: var(--bg-secondary); border-color: var(--border-primary)">
     <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-700/50">
-        <thead class="bg-gray-800/60">
+      <table class="min-w-full divide-y" style="--tw-divide-opacity: 0.5; border-color: var(--border-primary)">
+        <thead style="background-color: var(--bg-accent)">
           <tr>
-            <th v-for="(h, i) in headers" :key="i" class="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+            <th v-for="(h, i) in headers" :key="i" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider"
+                style="color: var(--text-secondary)">
               {{ h }}
             </th>
           </tr>
         </thead>
-        <tbody class="bg-gray-800/30 divide-y divide-gray-700/30">
+        <tbody class="divide-y" style="background-color: var(--bg-accent); --tw-divide-opacity: 0.3; border-color: var(--border-secondary)">
           <tr v-if="items.length === 0 && !isLoading">
-            <td :colspan="headers.length" class="px-4 py-8 text-center text-gray-400">
+            <td :colspan="headers.length" class="px-4 py-8 text-center" style="color: var(--text-secondary)">
               <slot name="empty"></slot>
             </td>
           </tr>

--- a/src/views/ExpensesTracker.vue
+++ b/src/views/ExpensesTracker.vue
@@ -961,22 +961,22 @@ const filterByDate = () => {};
     .btn-secondary { @apply bg-white hover:bg-gray-100 text-gray-700 font-medium py-2.5 px-5 rounded-lg border border-gray-300 shadow-sm hover:shadow-md transform hover:-translate-y-0.5 transition-all duration-200 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed; }
     .btn-icon { @apply p-2 rounded-full transition-colors duration-150; }
     
-    .summary-card { @apply bg-white rounded-xl shadow-sm p-5 border-t-4 flex flex-col; }
-    .summary-title { @apply text-sm font-medium text-gray-500 mb-1; }
+    .summary-card { @apply rounded-xl shadow-sm p-5 border-t-4 flex flex-col; background-color: var(--bg-secondary); }
+    .summary-title { @apply text-sm font-medium mb-1; color: var(--text-secondary); }
     .summary-amount { @apply text-2xl font-bold leading-tight; }
     .summary-icon-bg { @apply flex items-center justify-center w-12 h-12 rounded-full; }
     
-    .chart-container { @apply bg-white rounded-xl shadow-sm p-4 sm:p-6; }
-    .chart-title { @apply text-lg font-semibold text-gray-800 mb-4; }
+    .chart-container { @apply rounded-xl shadow-sm p-4 sm:p-6; background-color: var(--bg-secondary); }
+    .chart-title { @apply text-lg font-semibold mb-4; color: var(--text-primary); }
     .chart-wrapper { @apply h-80 relative; }
-    .loading-placeholder, .no-data-placeholder { @apply absolute inset-0 flex items-center justify-center text-gray-500 text-sm bg-gray-50 rounded-md border border-dashed border-gray-300; }
+    .loading-placeholder, .no-data-placeholder { @apply absolute inset-0 flex items-center justify-center text-sm rounded-md border border-dashed; color: var(--text-secondary); background-color: var(--bg-primary); border-color: var(--border-primary); }
     
     .modal-overlay { @apply fixed inset-0 bg-black bg-opacity-30 backdrop-blur-sm z-50 flex justify-center items-center p-4; }
-    .modal-container { @apply bg-white rounded-xl shadow-2xl p-6 w-full max-w-md max-h-[90vh] overflow-y-auto; }
-    .modal-title { @apply text-xl font-bold text-gray-800 mb-5 text-center; }
+    .modal-container { @apply rounded-xl shadow-2xl p-6 w-full max-w-md max-h-[90vh] overflow-y-auto; background-color: var(--bg-secondary); }
+    .modal-title { @apply text-xl font-bold mb-5 text-center; color: var(--text-primary); }
     .alert-error { @apply bg-red-100 border border-red-200 text-red-700 text-sm p-3 rounded-md mb-4; }
 
-    .list-item-detailed { @apply bg-white p-3 rounded-lg flex justify-between items-center border border-gray-200 hover:bg-gray-50 transition-colors; }
+    .list-item-detailed { @apply p-3 rounded-lg flex justify-between items-center border transition-colors; background-color: var(--bg-secondary); border-color: var(--border-secondary); }
     
     .modal-enter-active, .modal-leave-active { transition: opacity 0.3s ease; }
     .modal-enter-from, .modal-leave-to { opacity: 0; }

--- a/src/views/Tiendas.vue
+++ b/src/views/Tiendas.vue
@@ -1,36 +1,36 @@
 <template>
-  <div class="max-w-7xl mx-auto px-2 sm:px-4 md:px-6 text-slate-700">
+  <div class="max-w-7xl mx-auto px-2 sm:px-4 md:px-6" style="color: var(--text-primary)">
 
     <div class="md3-card mb-8 py-4 px-6">
       <h2 class="text-2xl md:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-teal-500 to-emerald-500 mb-2 text-center">Registro de Tiendas</h2>
-      <p class="text-slate-500 text-center text-sm md:text-base">Gestiona y controla tus tiendas y servicios</p>
+      <p class="text-center text-sm md:text-base" style="color: var(--text-secondary)">Gestiona y controla tus tiendas y servicios</p>
     </div>
 
     <div v-if="tiendas.length > 0" class="mb-8">
-      <h3 class="text-xl font-semibold text-teal-600 mb-4">Resumen General</h3>
+      <h3 class="text-xl font-semibold mb-4" style="color: var(--brand-emerald-text)">Resumen General</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div class="md3-card border-l-4 border-teal-500 transition-all duration-300 hover:shadow-teal-500/10 flex items-center gap-3">
-          <div class="p-2 bg-teal-100 text-teal-600 rounded-full">
+        <div class="md3-card border-l-4 transition-all duration-300 flex items-center gap-3" style="border-left-color: var(--brand-emerald)">
+          <div class="p-2 rounded-full" style="background-color: var(--brand-emerald); color: var(--text-on-accent-bg)">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7l1.664 12.42A2 2 0 006.653 21h10.694a2 2 0 001.989-1.58L21 7" />
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 3l-4 4-4-4" />
             </svg>
           </div>
           <div>
-            <h4 class="font-bold text-lg text-slate-800 mb-1">Total de Tiendas Registradas</h4>
-            <p class="text-3xl font-bold text-slate-700">{{ resumenGeneral.totalTiendas }}</p>
+            <h4 class="font-bold text-lg mb-1" style="color: var(--text-primary)">Total de Tiendas Registradas</h4>
+            <p class="text-3xl font-bold" style="color: var(--text-primary)">{{ resumenGeneral.totalTiendas }}</p>
           </div>
         </div>
-        <div class="md3-card border-l-4 border-teal-500 transition-all duration-300 hover:shadow-teal-500/10 flex items-center gap-3">
-          <div class="p-2 bg-teal-100 text-teal-600 rounded-full">
+        <div class="md3-card border-l-4 transition-all duration-300 flex items-center gap-3" style="border-left-color: var(--brand-emerald)">
+          <div class="p-2 rounded-full" style="background-color: var(--brand-emerald); color: var(--text-on-accent-bg)">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-3.866 0-7 1.343-7 3v4a2 2 0 002 2h10a2 2 0 002-2v-4c0-1.657-3.134-3-7-3z" />
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8V6m0 0V4m0 2a2 2 0 114 0" />
             </svg>
           </div>
           <div>
-            <h4 class="font-bold text-lg text-slate-800 mb-1">Costo Total General</h4>
-            <p class="text-3xl font-bold text-slate-700">Q{{ (resumenGeneral.costoTotalGeneral || 0).toFixed(2) }}</p>
+            <h4 class="font-bold text-lg mb-1" style="color: var(--text-primary)">Costo Total General</h4>
+            <p class="text-3xl font-bold" style="color: var(--text-primary)">Q{{ (resumenGeneral.costoTotalGeneral || 0).toFixed(2) }}</p>
           </div>
         </div>
       </div>
@@ -49,20 +49,20 @@
             </svg>
           </div>
           <div>
-            <h4 class="font-bold text-lg text-slate-800 mb-1">{{ marcaResumen.nombre }}</h4>
-            <p class="text-sm text-slate-500">Tiendas: <span class="font-medium text-slate-700">{{ marcaResumen.conteo }}</span></p>
-            <p class="text-sm text-slate-500">Ingresos Totales: <span class="font-medium text-slate-700">Q{{ (marcaResumen.ingresos || 0).toFixed(2) }}</span></p>
+            <h4 class="font-bold text-lg mb-1" style="color: var(--text-primary)">{{ marcaResumen.nombre }}</h4>
+            <p class="text-sm" style="color: var(--text-secondary)">Tiendas: <span class="font-medium" style="color: var(--text-primary)">{{ marcaResumen.conteo }}</span></p>
+            <p class="text-sm" style="color: var(--text-secondary)">Ingresos Totales: <span class="font-medium" style="color: var(--text-primary)">Q{{ (marcaResumen.ingresos || 0).toFixed(2) }}</span></p>
           </div>
         </div>
       </div>
     </div>
 
     <div v-if="resumenPorConsultor.length > 0" class="mb-8">
-      <h3 class="text-xl font-semibold text-teal-600 mb-4">Resumen por Consultor</h3>
+      <h3 class="text-xl font-semibold mb-4" style="color: var(--brand-emerald-text)">Resumen por Consultor</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         <div v-for="(consultorResumen, index) in resumenPorConsultor" :key="index"
-             class="md3-card border-l-4 border-teal-500 transition-all duration-300 hover:shadow-teal-500/10 flex items-center gap-3">
-          <div class="p-2 bg-teal-100 text-teal-600 rounded-full">
+             class="md3-card border-l-4 transition-all duration-300 flex items-center gap-3" style="border-left-color: var(--brand-emerald)">
+          <div class="p-2 rounded-full" style="background-color: var(--brand-emerald); color: var(--text-on-accent-bg)">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857"/>
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20H4v-2a3 3 0 015.356-1.857"/>
@@ -70,9 +70,9 @@
             </svg>
           </div>
           <div>
-            <h4 class="font-bold text-lg text-slate-800 mb-1">{{ consultorResumen.nombre }}</h4>
-            <p class="text-sm text-slate-500">Tiendas Asignadas: <span class="font-medium text-slate-700">{{ consultorResumen.conteo }}</span></p>
-            <p class="text-sm text-slate-500">Ingresos Totales: <span class="font-medium text-slate-700">Q{{ (consultorResumen.ingresos || 0).toFixed(2) }}</span></p>
+            <h4 class="font-bold text-lg mb-1" style="color: var(--text-primary)">{{ consultorResumen.nombre }}</h4>
+            <p class="text-sm" style="color: var(--text-secondary)">Tiendas Asignadas: <span class="font-medium" style="color: var(--text-primary)">{{ consultorResumen.conteo }}</span></p>
+            <p class="text-sm" style="color: var(--text-secondary)">Ingresos Totales: <span class="font-medium" style="color: var(--text-primary)">Q{{ (consultorResumen.ingresos || 0).toFixed(2) }}</span></p>
           </div>
         </div>
       </div>
@@ -80,7 +80,7 @@
 
     <div class="md3-card mb-10 overflow-hidden">
       <div class="bg-slate-50 border-b border-gray-200 px-6 py-4">
-        <h3 class="text-lg font-semibold text-teal-600">
+        <h3 class="text-lg font-semibold" style="color: var(--brand-emerald-text)">
           {{ modoEdicion ? 'Editar Tienda' : 'Nueva Tienda' }}
         </h3>
       </div>


### PR DESCRIPTION
## Summary
- use CSS variables in common light components
- update DataTable background and text colors
- adjust ExpensesTracker styles for theming
- begin replacing hardcoded colors in Tiendas view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849066269f4832c8b15f7fd56765aa7