### PR TITLE
Fix option-light class in light-components.css

### DIFF
--- a/src/assets/css/light-components.css
+++ b/src/assets/css/light-components.css
@@ -39,7 +39,6 @@
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%2314b8a6' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
 }
 .option-light {
-  @apply;
   background-color: var(--bg-secondary);
   color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary
- remove stray `@apply;` from option-light class
- keep only background-color and color in `.option-light`

## Testing
- `grep -n "@apply;" -n src/assets/css/light-components.css`

------
https://chatgpt.com/codex/tasks/task_e_68490926bea8832cbd86e1baf405511b